### PR TITLE
fix: Incorrect module link

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Ferluci/fast-realip
+module github.com/Ferluci/fasthttp-realip
 
 go 1.12
 


### PR DESCRIPTION
I can't import your library due to the repository rename, merging this would be appreciated

```
go: downloading github.com/Ferluci/fasthttp-realip v1.0.0
go get: github.com/Ferluci/fasthttp-realip@none updating to
github.com/Ferluci/fasthttp-realip@v1.0.0: parsing go.mod:
module declares its path as: github.com/Ferluci/fast-realip
but was required as: github.com/Ferluci/fasthttp-realip
make: *** [Makefile:6: heartbeat] Error 1
```